### PR TITLE
Add "Wolfram Language" as language alias for Jupyter Notebook VSCode Integration

### DIFF
--- a/extension/package.json.in
+++ b/extension/package.json.in
@@ -28,7 +28,8 @@
 				"id": "wolfram",
 				"aliases": [
 					"Wolfram",
-					"wolfram"
+					"wolfram",
+					"Wolfram Language"
 				],
 				"extensions": [
 					".wl",


### PR DESCRIPTION

VSCode has jupyter notebook integration and it detects language from `metadata.language_info.name`.

https://github.com/microsoft/vscode/blob/7e57af782039727e21d8e63ce0c671ce9004286b/extensions/ipynb/src/deserializers.ts#L19:L23

And [WolframResearch/WolframLanguageForJupyter](https://github.com/WolframResearch/WolframLanguageForJupyter) uses `Wolfram Language` for this value.

https://github.dev/WolframResearch/WolframLanguageForJupyter/blob/9a26ac78743cc47084c9c99ff75c5aee2657a409/WolframLanguageForJupyter/Resources/KernelForWolframLanguageForJupyter.wl#L89-L90

I tested the behavior with publishing to open-vsx.org under my namespace. (https://open-vsx.org/extension/luma/wolfram)